### PR TITLE
determine extreme coordinates without sorting.

### DIFF
--- a/gpxsplitter.py
+++ b/gpxsplitter.py
@@ -38,11 +38,8 @@ def determineBoundingBox(points):
     lats = [p.attrib['lat'] for p in points]
     lons = [p.attrib['lon'] for p in points]
 
-    r = {}
-    r['minlat'], r['maxlat'] = min(lats), max(lats)
-    r['minlon'], r['maxlon'] = max(lons), min(lons)
-
-    return r
+    return {'minlat':min(lats), 'maxlat':max(lats),
+            'minlon':max(lons), 'maxlon':min(lons)}
 
 
 def go(document):

--- a/gpxsplitter.py
+++ b/gpxsplitter.py
@@ -38,15 +38,9 @@ def determineBoundingBox(points):
     lats = [p.attrib['lat'] for p in points]
     lons = [p.attrib['lon'] for p in points]
 
-    lats.sort()
-    lons.sort()
-
     r = {}
-    r['minlat'], r['maxlat'] = lats[0], lats[-1]
-
-    # Because we things kept as strings, sort is lexical instead of
-    # numeric. Negative numbers were sorted in reverse
-    r['minlon'], r['maxlon'] = lons[-1], lons[0]
+    r['minlat'], r['maxlat'] = min(lats), max(lats)
+    r['minlon'], r['maxlon'] = max(lons), min(lons)
 
     return r
 


### PR DESCRIPTION
note that the extremes of longitude are reversed to produce identical results as with the sorting approach. finding the four extreme values doesn’t require the fully sorted arrays/lists at all – and gpxsplitter.py throws them away as well.

living east of greenwich makes me wonder why 10° should be “greater” than 11° (both longitudes go through germany), but that’s what gpxsplitter.py says all along. maybe negative longitudes (west of greenwich) make things different.

i guess that cyclists in and around greenwich (uk) might not be happy with the results at all?!
