### PR TITLE
Minmax

### DIFF
--- a/gpxsplitter.py
+++ b/gpxsplitter.py
@@ -35,18 +35,15 @@ def determineBoundingBox(points):
     """Determine the bounding box of a set of points.
     """
     # This is slow. But works correctly.
-    lats = [p.attrib['lat'] for p in points]
-    lons = [p.attrib['lon'] for p in points]
+    lats = [float(p.attrib['lat']) for p in points]
+    lons = [float(p.attrib['lon']) for p in points]
 
     lats.sort()
     lons.sort()
 
     r = {}
-    r['minlat'], r['maxlat'] = lats[0], lats[-1]
-
-    # Because we things kept as strings, sort is lexical instead of
-    # numeric. Negative numbers were sorted in reverse
-    r['minlon'], r['maxlon'] = lons[-1], lons[0]
+    r['minlat'], r['maxlat'] = str(lats[0]), str(lats[-1])
+    r['minlon'], r['maxlon'] = str(lons[0]), str(lons[-1])
 
     return r
 

--- a/minmax/2014-11-01T09:18:57Z.gpx
+++ b/minmax/2014-11-01T09:18:57Z.gpx
@@ -1,0 +1,59 @@
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mtk="http://www.rigacci.org/gpx/MtkExtensions/v1" version="1.1" creator="MTKBabel - http://www.rigacci.org/" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd                       http://www.rigacci.org/gpx/MtkExtensions/v1 http://www.rigacci.org/gpx/MtkExtensions/v1/MtkExtensionsv1.xsd">
+<metadata>
+  <time>2014-11-01T09:18:57Z</time>
+  <bounds minlat="-10.0" minlon="15.0" maxlat="5.0" maxlon="-10.0"/>
+</metadata>
+<trk>
+  <name>2014-11-01T09:18:25Z</name>
+<trkseg>
+<trkpt lat="-10.0" lon="-10.0">
+  <ele>334.252747</ele>
+  <time>2014-11-01T09:18:25Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>22.537603</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+<trkpt lat="5.0" lon="-5.0">
+  <ele>333.165619</ele>
+  <time>2014-11-01T09:18:33Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>24.877300</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+<trkpt lat="5.0" lon="10.0">
+  <ele>332.925507</ele>
+  <time>2014-11-01T09:18:41Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>25.415138</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+<trkpt lat="-15.0" lon="15.0">
+  <ele>333.124451</ele>
+  <time>2014-11-01T09:18:57Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>19.152020</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/minmax/2014-11-01T09:18:57Z.gpx
+++ b/minmax/2014-11-01T09:18:57Z.gpx
@@ -1,7 +1,7 @@
 <gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mtk="http://www.rigacci.org/gpx/MtkExtensions/v1" version="1.1" creator="MTKBabel - http://www.rigacci.org/" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd                       http://www.rigacci.org/gpx/MtkExtensions/v1 http://www.rigacci.org/gpx/MtkExtensions/v1/MtkExtensionsv1.xsd">
 <metadata>
   <time>2014-11-01T09:18:57Z</time>
-  <bounds minlat="-10.0" minlon="15.0" maxlat="5.0" maxlon="-10.0"/>
+  <bounds minlat="-15.0" minlon="-10.0" maxlat="5.0" maxlon="15.0"/>
 </metadata>
 <trk>
   <name>2014-11-01T09:18:25Z</name>

--- a/minmax/20141120.gpx
+++ b/minmax/20141120.gpx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx
+  version="1.1"
+  creator="MTKBabel - http://www.rigacci.org/"
+  xmlns="http://www.topografix.com/GPX/1/1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:mtk="http://www.rigacci.org/gpx/MtkExtensions/v1"
+  xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd
+                      http://www.rigacci.org/gpx/MtkExtensions/v1 http://www.rigacci.org/gpx/MtkExtensions/v1/MtkExtensionsv1.xsd">
+<metadata>
+  <time>2014-11-20T17:05:29Z</time>
+  <bounds minlat="-15.0" minlon="-10.0" maxlat="5.0" maxlon="15.0"/>
+</metadata>
+<trk>
+  <name>2014-11-01T09:18:25Z</name>
+<trkseg>
+<trkpt lat="-10.0" lon="-10.0">
+  <ele>334.252747</ele>
+  <time>2014-11-01T09:18:25Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>22.537603</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+<trkpt lat="5.0" lon="-5.0">
+  <ele>333.165619</ele>
+  <time>2014-11-01T09:18:33Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>24.877300</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+<trkpt lat="5.0" lon="10.0">
+  <ele>332.925507</ele>
+  <time>2014-11-01T09:18:41Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>25.415138</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+<trkpt lat="-15.0" lon="15.0">
+  <ele>333.124451</ele>
+  <time>2014-11-01T09:18:57Z</time>
+  <type>DISTANCE</type>
+  <fix>3d</fix>
+  <extensions>
+    <mtk:wptExtension>
+      <mtk:valid>sps</mtk:valid>
+      <mtk:speed>19.152020</mtk:speed>
+    </mtk:wptExtension>
+  </extensions>
+</trkpt>
+</trkseg>
+</trk>
+</gpx>


### PR DESCRIPTION
[what goes around, comes around](https://github.com/samatjain/gpxsplitter/pull/1).

gpxsplitter really should work with numerical coordinates when determining the bounding box of an output track. a small input track and two _different_ output results are included for clarification.
